### PR TITLE
Create Firestore user doc on sign-up and scope trips to user

### DIFF
--- a/app/register.tsx
+++ b/app/register.tsx
@@ -1,4 +1,5 @@
 import { createUserWithEmailAndPassword } from "firebase/auth";
+import { doc, setDoc } from "firebase/firestore";
 import { LinearGradient } from "expo-linear-gradient";
 import { router } from "expo-router";
 import { StatusBar } from "expo-status-bar";
@@ -16,7 +17,7 @@ import {
   View,
 } from "react-native";
 
-import { auth } from "@/firebaseConfig";
+import { auth, db } from "@/firebaseConfig";
 
 const { height } = Dimensions.get("window");
 
@@ -39,7 +40,11 @@ export default function Register() {
 
     setLoading(true);
     try {
-      await createUserWithEmailAndPassword(auth, email, password);
+      const { user } = await createUserWithEmailAndPassword(auth, email, password);
+      await setDoc(doc(db, "users", user.uid), {
+        userId: user.uid,
+        email: user.email,
+      });
       router.replace("/trips");
     } catch (error: any) {
       const code = error.code;


### PR DESCRIPTION
## Summary
- On registration, create a document in the `/users` collection with the user's `userId` and `email`
- Scope trips queries to the authenticated user via `where("userId", "==", user.uid)`
- Store `userId` on new trips for ownership tracking
- Redirect to `/login` if no authenticated user on the trips screen
- Fix `trips.tsx` import to use `@/` path alias

## Test plan
- [x] Register a new user and verify a document is created in Firestore `/users/{uid}`
- [x] Create a trip and verify it has a `userId` field matching the authenticated user
- [x] Log in as a different user and verify they only see their own trips
- [x] Navigate to /trips without being logged in and verify redirect to /login

🤖 Generated with [Claude Code](https://claude.com/claude-code)